### PR TITLE
ForecastSchedule element name mismatch with XSD

### DIFF
--- a/IDL/CommonModule.idl
+++ b/IDL/CommonModule.idl
@@ -243,13 +243,13 @@ module commonmodule {
 	};
 	//@top-level false
 
-	const unsigned long MaxLengthForecastScheduleIrregularTimePoints = 100;
-	typedef sequence<IrregularTimePoint, MaxLengthForecastScheduleIrregularTimePoints> SequenceOfForecastScheduleIrregularTimePoints;
+	const unsigned long MaxLengthForecastScheduleIrregularTimePoint = 100;
+	typedef sequence<IrregularTimePoint, MaxLengthForecastScheduleIrregularTimePoint> SequenceOfForecastScheduleIrregularTimePoint;
 
 	struct ForecastSchedule : BasicIntervalSchedule {
 		string version;   
 		DateTimeType versionDateTime;   
-		SequenceOfForecastScheduleIrregularTimePoints irregularTimePoints;
+		SequenceOfForecastScheduleIrregularTimePoint irregularTimePoint;
 	};
 	//@top-level false
 


### PR DESCRIPTION
In the XSD for CommonModule that was submitted to NAESB, the "irregularTimePoint" element is not plural.  After checking with Shawn Hu, this is the explanation for why:

"I believe the 's' was there in an early version since according to the CIM convention, an XSD element name goes with the UML association role name. And a role name usually goes with the multiplicity such as IrregularTimePoints for an 0..* relationship but not always. I checked the model again, the role name is not present in the current model hence its end class name is used as default"